### PR TITLE
add shebang line

### DIFF
--- a/jumpcutter.py
+++ b/jumpcutter.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 from contextlib import closing
 from PIL import Image
 import subprocess


### PR DESCRIPTION
added shebang line so instead of "python jumpcutter.py -h", you can just use "jumpcutter.py -h" Note: only works on bash though