### PR TITLE
ffmpeg extra custom encoding parameters for increasing encoding speed

### DIFF
--- a/jumpcutter.py
+++ b/jumpcutter.py
@@ -63,6 +63,8 @@ parser.add_argument('--frame_margin', type=float, default=1, help="some silent f
 parser.add_argument('--sample_rate', type=float, default=44100, help="sample rate of the input and output videos")
 parser.add_argument('--frame_rate', type=float, default=30, help="frame rate of the input and output videos. optional... I try to find it out myself, but it doesn't always work.")
 parser.add_argument('--frame_quality', type=int, default=3, help="quality of frames to be extracted from input video. 1 is highest, 31 is lowest, 3 is the default.")
+parser.add_argument('--preset', type=str, default="ultrafast", help="A preset is a collection of options that will provide a certain encoding speed to compression ratio. See https://trac.ffmpeg.org/wiki/Encode/H.264")
+parser.add_argument('--crf', type=int, default=18, help="Constant Rate Factor (CRF). Lower value - better quality but large filesize. See https://trac.ffmpeg.org/wiki/Encode/H.264")
 
 args = parser.parse_args()
 
@@ -79,6 +81,8 @@ else:
     INPUT_FILE = args.input_file
 URL = args.url
 FRAME_QUALITY = args.frame_quality
+H264_PRESET = args.preset
+H264_CRF = args.crf
 
 assert INPUT_FILE != None , "why u put no input file, that dum"
     
@@ -197,7 +201,7 @@ for endGap in range(outputFrame,audioFrameCount):
     copyFrame(int(audioSampleCount/samplesPerFrame)-1,endGap)
 '''
 
-command = "ffmpeg -framerate "+str(frameRate)+" -i "+TEMP_FOLDER+"/newFrame%06d.jpg -i "+TEMP_FOLDER+"/audioNew.wav -strict -2 "+OUTPUT_FILE
+command = f"ffmpeg -framerate {frameRate} -i {TEMP_FOLDER}/newFrame%06d.jpg -i {TEMP_FOLDER}/audioNew.wav -strict -2 -c:v libx264 -preset {H264_PRESET} -crf {H264_CRF} -pix_fmt yuvj420p {OUTPUT_FILE}"
 subprocess.call(command, shell=True)
 
 deletePath(TEMP_FOLDER)


### PR DESCRIPTION
Added several parameters in ffmpeg encoding command:
`-c:v libx264` - shows what encoder is used by default
`-preset {H264_PRESET}` - set ffmpeg preset for tuning encoding speed.
`-crf {H264_CRF}` - Constant Rate Factor (CRF) is the quality, lower means better quality and height encoding speed
`-pix_fmt yuvj420p` - specifies the pixel format. Video will work in QuickTime and most other players.

You can increase up to ~1.2x encoding speed or reduce file size.

More information:
https://trac.ffmpeg.org/wiki/Encode/H.264

