### PR TITLE
print all frame copy messages on the same line

### DIFF
--- a/jumpcutter.py
+++ b/jumpcutter.py
@@ -30,7 +30,8 @@ def copyFrame(inputFrame,outputFrame):
         return False
     copyfile(src, dst)
     if outputFrame%20 == 19:
-        print(str(outputFrame+1)+" time-altered frames saved.")
+        print(str(outputFrame + 1) + " time-altered frames saved.", end="\r", flush=True)
+        # print all frame copy messages on the same line
     return True
 
 def inputToOutputFilename(filename):
@@ -188,6 +189,8 @@ for chunk in chunks:
             copyFrame(lastExistingFrame,outputFrame)
 
     outputPointer = endPointer
+
+print()  # start a new line after reusing the same line for all frame copies
 
 wavfile.write(TEMP_FOLDER+"/audioNew.wav",SAMPLE_RATE,outputAudioData)
 


### PR DESCRIPTION
It's pretty annoying and not very informative if every frame copy prints a new line of text; Especially with large files.