### PR TITLE
Added timestamp to TEMP-Folder name.

### DIFF
--- a/jumpcutter.py
+++ b/jumpcutter.py
@@ -11,6 +11,7 @@ from shutil import copyfile, rmtree
 import os
 import argparse
 from pytube import YouTube
+import time
 
 def downloadFile(url):
     name = YouTube(url).streams.first().download()
@@ -87,7 +88,7 @@ if len(args.output_file) >= 1:
 else:
     OUTPUT_FILE = inputToOutputFilename(INPUT_FILE)
 
-TEMP_FOLDER = "TEMP"
+TEMP_FOLDER = "TEMP" + str(time.time())
 AUDIO_FADE_ENVELOPE_SIZE = 400 # smooth out transitiion's audio by quickly fading in/out (arbitrary magic number whatever)
     
 createPath(TEMP_FOLDER)


### PR DESCRIPTION
This should allow multiple jumpcutter processes running at the same time.

This solution is pretty hacky. If you like the feature feel free to use a counter or some other way to name the folders.