### PR TITLE
Fix nix-build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -35,7 +35,7 @@ let
       mkdir -p $out/bin
       echo "#!${pythonForThis}/bin/python" > $out/bin/jumpcutter
       cat $src/jumpcutter.py >> $out/bin/jumpcutter
-      substituteInPlace $out/bin/jumpcutter --replace ffmpeg ${ffmpeg}
+      substituteInPlace $out/bin/jumpcutter --replace ffmpeg ${ffmpeg}/bin/ffmpeg
       chmod +x $out/bin/jumpcutter
     '';
   };


### PR DESCRIPTION
`nix-build` is broken.  `ffmpeg` should be replaced with `${ffmpeg}/bin/ffmpeg` rather than just `${ffmpeg}` which is just the directory where the ffmpeg derivation lives.