### PR TITLE
update requirement pytube to pytube3 for py3+ compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Pillow
 audiotsm
 scipy
 numpy
-pytube
+pytube3


### PR DESCRIPTION
Super basic request. As Python 2+is deprecated and no longer maintained I would suggest moving the script to Python 3+.

It seems that the only preventing factor was a dependency on **pytube** which seems to have some issues within python 3.7.x as well as python 3.8.

The drop in replacement I found would be [get-pytube/pytube3](https://github.com/get-pytube/pytube3).

This PR just adds that as the requirement replacing pytube.