### PR TITLE
Fix yt video file that contains "&" failing

### DIFF
--- a/jumpcutter.py
+++ b/jumpcutter.py
@@ -14,7 +14,7 @@ from pytube import YouTube
 
 def downloadFile(url):
     name = YouTube(url).streams.first().download()
-    newname = name.replace(' ','_')
+    newname = (name.replace(' ','_')).replace('&','and')
     os.rename(name,newname)
     return newname
 


### PR DESCRIPTION
Basic change to also replace "&" with "and" for youtube video files that contain "&" as the script is failing on windows when trying to use jump cutter on videos title with "&"