### PR TITLE
Safe file names

### DIFF
--- a/jumpcutter.py
+++ b/jumpcutter.py
@@ -86,16 +86,20 @@ if len(args.output_file) >= 1:
     OUTPUT_FILE = args.output_file
 else:
     OUTPUT_FILE = inputToOutputFilename(INPUT_FILE)
+    
+# Safe file name for dots and blanks
+SAFE_INPUT_FILE = "\""+INPUT_FILE+"\""
+SAFE_OUTPUT_FILE = "\""+OUTPUT_FILE+"\""
 
 TEMP_FOLDER = "TEMP"
 AUDIO_FADE_ENVELOPE_SIZE = 400 # smooth out transitiion's audio by quickly fading in/out (arbitrary magic number whatever)
     
 createPath(TEMP_FOLDER)
 
-command = "ffmpeg -i "+INPUT_FILE+" -qscale:v "+str(FRAME_QUALITY)+" "+TEMP_FOLDER+"/frame%06d.jpg -hide_banner"
+command = "ffmpeg -i "+SAFE_INPUT_FILE+" -qscale:v "+str(FRAME_QUALITY)+" "+TEMP_FOLDER+"/frame%06d.jpg -hide_banner"
 subprocess.call(command, shell=True)
 
-command = "ffmpeg -i "+INPUT_FILE+" -ab 160k -ac 2 -ar "+str(SAMPLE_RATE)+" -vn "+TEMP_FOLDER+"/audio.wav"
+command = "ffmpeg -i "+SAFE_INPUT_FILE+" -ab 160k -ac 2 -ar "+str(SAMPLE_RATE)+" -vn "+TEMP_FOLDER+"/audio.wav"
 
 subprocess.call(command, shell=True)
 
@@ -197,7 +201,7 @@ for endGap in range(outputFrame,audioFrameCount):
     copyFrame(int(audioSampleCount/samplesPerFrame)-1,endGap)
 '''
 
-command = "ffmpeg -framerate "+str(frameRate)+" -i "+TEMP_FOLDER+"/newFrame%06d.jpg -i "+TEMP_FOLDER+"/audioNew.wav -strict -2 "+OUTPUT_FILE
+command = "ffmpeg -framerate "+str(frameRate)+" -i "+TEMP_FOLDER+"/newFrame%06d.jpg -i "+TEMP_FOLDER+"/audioNew.wav -strict -2 "+SAFE_OUTPUT_FILE
 subprocess.call(command, shell=True)
 
 deletePath(TEMP_FOLDER)


### PR DESCRIPTION
I faced a problem about it. 
```py
command = "ffmpeg -i 9. Introduction Testing.ts -qscale:v 3 TEMP/frame%06d.jpg -hide_banner"
```
This is not solvable for OS. Some trick is going to solve it.
```py
command = "ffmpeg -i \"9. Introduction Testing.ts\" -qscale:v 3 TEMP/frame%06d.jpg -hide_banner"
```
After this cmd working like
```bash
ffmpeg -i "9. Introduction Testing.ts" -qscale:v 3 TEMP/frame%06d.jpg -hide_banner
```
Tested and work.