### PR TITLE
Fix YouTube videos downloading in low quality.

### DIFF
--- a/jumpcutter.py
+++ b/jumpcutter.py
@@ -13,7 +13,7 @@ import argparse
 from pytube import YouTube
 
 def downloadFile(url):
-    name = YouTube(url).streams.first().download()
+    name = YouTube(url).streams.get_highest_quality().download()
     newname = name.replace(' ','_')
     os.rename(name,newname)
     return newname


### PR DESCRIPTION
Youtube videos downloaded with the --url argument download in a super low quality with no obvious way to fix it. This simple change will download it in the highest quality instead of the lowest.